### PR TITLE
Remove text from within `ix:exclude` tags

### DIFF
--- a/ixbrlparse/core.py
+++ b/ixbrlparse/core.py
@@ -145,6 +145,8 @@ class IXBRLParser(BaseParser):
                 format_ = s.get("format")
                 if not isinstance(format_, str):
                     format_ = None
+                if s.find("exclude"):
+                    s.find("exclude").extract()
                 self.nonnumeric.append(
                     ixbrlNonNumeric(
                         context=context,


### PR DESCRIPTION
As per the XBRL definition of the '[exclude statement](https://www.xbrl.org/specification/inlinexbrl-part1/rec-2013-11-18/inlinexbrl-part1-rec-2013-11-18.html#d1e1605)', this PR removes the text from within that non numeric element. See example of exclude tag in [these accounts](https://find-and-update.company-information.service.gov.uk/company/10284499/filing-history/MzM2MjU0NjE3N2FkaXF6a2N4/document?format=xhtml&download=1).